### PR TITLE
Syncronisation of node types against Estraverse's VisitorKeys

### DIFF
--- a/lib/instrumenter-core.js
+++ b/lib/instrumenter-core.js
@@ -2,8 +2,10 @@
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
+var visitorKeys = require('estraverse').VisitorKeys;
+
 module.exports = function (opts) {
-    var SYNTAX,
+    var SYNTAX = {},
         SourceCoverage = require('./source-coverage'),
         ESP = opts.parser,
         ESPGEN = opts.codegen,
@@ -22,83 +24,8 @@ module.exports = function (opts) {
         Array.prototype.push.apply(ary, thing);
     }
 
-    SYNTAX = {
-        // keep in sync with estraverse's VisitorKeys
-        AssignmentExpression: ['left', 'right'],
-        AssignmentPattern: ['left', 'right'],
-        ArrayExpression: ['elements'],
-        ArrayPattern: ['elements'],
-        ArrowFunctionExpression: ['params', 'body'],
-        AwaitExpression: ['argument'], // CAUTION: It's deferred to ES7.
-        BlockStatement: ['body'],
-        BinaryExpression: ['left', 'right'],
-        BreakStatement: ['label'],
-        CallExpression: ['callee', 'arguments'],
-        CatchClause: ['param', 'body'],
-        ClassBody: ['body'],
-        ClassDeclaration: ['id', 'superClass', 'body'],
-        ClassExpression: ['id', 'superClass', 'body'],
-        ComprehensionBlock: ['left', 'right'],  // CAUTION: It's deferred to ES7.
-        ComprehensionExpression: ['blocks', 'filter', 'body'],  // CAUTION: It's deferred to ES7.
-        ConditionalExpression: ['test', 'consequent', 'alternate'],
-        ContinueStatement: ['label'],
-        DebuggerStatement: [],
-        DirectiveStatement: [],
-        DoWhileStatement: ['body', 'test'],
-        EmptyStatement: [],
-        ExportAllDeclaration: ['source'],
-        ExportDefaultDeclaration: ['declaration'],
-        ExportNamedDeclaration: ['declaration', 'specifiers', 'source'],
-        ExportSpecifier: ['exported', 'local'],
-        ExpressionStatement: ['expression'],
-        ForStatement: ['init', 'test', 'update', 'body'],
-        ForInStatement: ['left', 'right', 'body'],
-        ForOfStatement: ['left', 'right', 'body'],
-        FunctionDeclaration: ['id', 'params', 'body'],
-        FunctionExpression: ['id', 'params', 'body'],
-        GeneratorExpression: ['blocks', 'filter', 'body'],  // CAUTION: It's deferred to ES7.
-        Identifier: [],
-        IfStatement: ['test', 'consequent', 'alternate'],
-        ImportDeclaration: ['specifiers', 'source'],
-        ImportDefaultSpecifier: ['local'],
-        ImportNamespaceSpecifier: ['local'],
-        ImportSpecifier: ['imported', 'local'],
-        Literal: [],
-        LabeledStatement: ['label', 'body'],
-        LogicalExpression: ['left', 'right'],
-        MetaProperty: ['meta', 'property'],
-        MemberExpression: ['object', 'property'],
-        MethodDefinition: ['key', 'value'],
-        ModuleSpecifier: [],
-        NewExpression: ['callee', 'arguments'],
-        ObjectExpression: ['properties'],
-        ObjectPattern: ['properties'],
-        Program: ['body'],
-        Property: ['key', 'value'],
-        RestElement: ['argument'],
-        ReturnStatement: ['argument'],
-        SequenceExpression: ['expressions'],
-        SpreadElement: ['argument'],
-        SuperExpression: ['super'],
-        SwitchStatement: ['discriminant', 'cases'],
-        SwitchCase: ['test', 'consequent'],
-        TaggedTemplateExpression: ['tag', 'quasi'],
-        TemplateElement: [],
-        TemplateLiteral: ['quasis', 'expressions'],
-        ThisExpression: [],
-        ThrowStatement: ['argument'],
-        TryStatement: ['block', 'handler', 'finalizer'],
-        UnaryExpression: ['argument'],
-        UpdateExpression: ['argument'],
-        VariableDeclaration: ['declarations'],
-        VariableDeclarator: ['id', 'init'],
-        WhileStatement: ['test', 'body'],
-        WithStatement: ['object', 'body'],
-        YieldExpression: ['argument']
-    };
-
-    Object.keys(SYNTAX).forEach(function (nodeType) {
-        SYNTAX[nodeType] = { name: nodeType, children: SYNTAX[nodeType]};
+    Object.keys(visitorKeys).forEach(function (nodeType) {
+        SYNTAX[nodeType] = { name: nodeType, children: visitorKeys[nodeType]};
     });
 
     astgen = {
@@ -1021,4 +948,3 @@ module.exports = function (opts) {
 
     return Instrumenter;
 };
-

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "escodegen": "^1.8.0",
     "esprima": "^2.7",
+    "estraverse": "^4.2.0",
     "istanbul-lib-coverage": "^1.0.0-alpha"
   },
   "devDependencies": {


### PR DESCRIPTION
I've noticed a disparity in node type names between the [static list of node types](https://github.com/istanbuljs/istanbul-lib-instrument/blob/master/lib/instrumenter-core.js#L25) in `istanbul-lib-instrument` and [`estraverse`'s representation](https://github.com/estools/estraverse/blob/6f6a4e99653908e859c7c10d04d9518bf4844ede/estraverse.js#L218) - namely the difference in name between [`Super`](https://github.com/estools/estraverse/blob/6f6a4e99653908e859c7c10d04d9518bf4844ede/estraverse.js#L274) and [`SuperExpression`](https://github.com/istanbuljs/istanbul-lib-instrument/blob/master/lib/instrumenter-core.js#L82) node types. This results in the following error in my setup:

```js
Unsupported node type:Super
```

Maintenance can be reduced by referring directly to the list of node types that Estraverse contains.