### PR TITLE
Add side-effects-only processing for --all support

### DIFF
--- a/bin/test-instrument
+++ b/bin/test-instrument
@@ -7,12 +7,18 @@ const nopt = require('nopt');
 const opts = {
     "compact": Boolean,
     "module": Boolean,
-    "sourcemaps": Boolean
+    "sourcemaps": Boolean,
+    "side-effects-only": Boolean
 };
 const parsed = nopt(opts, null, process.argv, 2);
 
 const args = parsed.argv.remain;
-const inst = createInstrumenter({compact: parsed.compact, esModules: parsed.module, produceSourceMap: parsed.sourcemaps});
+const inst = createInstrumenter({
+    compact: parsed.compact,
+    esModules: parsed.module,
+    produceSourceMap: parsed.sourcemaps,
+    sideEffectsOnly: parsed['side-effects-only']
+});
 
 args.forEach(function (file) {
     const content = readFileSync(file, 'utf8');

--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -17,7 +17,8 @@ function defaultOpts() {
         autoWrap: false,
         produceSourceMap: false,
         sourceMapUrlCallback: null,
-        debug: false
+        debug: false,
+        sideEffectsOnly: false
     };
 }
 /**
@@ -35,6 +36,8 @@ function defaultOpts() {
  * @param {Function} [opts.sourceMapUrlCallback=null] a callback function that is called when a source map URL
  *     is found in the original code. This function is called with the source file name and the source map URL.
  * @param {boolean} [opts.debug=false] - turn debugging on
+ * @param {boolean} [opts.sideEffectsOnly=false] - process code for side-effects only. The returned code will
+ *  only have statements that pertain to coverage object processing and none of the original code.
  */
 class Instrumenter {
     constructor(opts=defaultOpts()) {
@@ -80,7 +83,8 @@ class Instrumenter {
             sourceType: opts.esModules ? "module" : "script"
         });
         const ee = programVisitor(t, filename, {
-            coverageVariable: opts.coverageVariable
+            coverageVariable: opts.coverageVariable,
+            sideEffectsOnly: opts.sideEffectsOnly
         });
         let output = {};
         const visitor = {

--- a/test/specs/side-effects.yaml
+++ b/test/specs/side-effects.yaml
@@ -1,0 +1,13 @@
+---
+name: simple statement, side-effect only
+code: |
+  var x = args[0] > 5 ? args[0] : "undef";
+  output = x;
+instrumentOpts:
+  sideEffectsOnly: true
+tests:
+  - name: does not cover anything
+    args: [10]
+    lines: {'1': 0, '2': 0}
+    branches: {'1': [0, 0]}
+    statements: {'1': 0, '2': 0}

--- a/test/specs/statement-hints.yaml
+++ b/test/specs/statement-hints.yaml
@@ -91,6 +91,17 @@ tests:
     statements: {'1': 1}
 
 ---
+name: ignore before ternary alternate
+code: |
+  output = args[0] === 1 ?  1 : /* istanbul ignore next */ 0;
+tests:
+  - args: [1]
+    out: 1
+    lines: {'1': 1}
+    branches: {'1': [1]}
+    statements: {'1': 1}
+
+---
 name: ignore in logical expression
 code: |
   if (args[0] === 1  || /* istanbul ignore next */ args[0] === 2 ) {


### PR DESCRIPTION
@bcoe, take a look and see if this will meet your needs.

The annoyance in the interface is that you need to create 2 instrumenters, one for "regular" processing and another for side-effects only. If this is an issue, we could add a method on the instrumenter to create a new one using current options as well as with the side effects flag set (e.g. `instrumenter.withSideEffectsOnly`).

Let me know.