### PR TITLE
Hoist coverage variable to very top of file

### DIFF
--- a/src/visitor.js
+++ b/src/visitor.js
@@ -474,6 +474,7 @@ function programVisitor(types, sourceFilePath = 'unknown.js', opts = {coverageVa
                 INITIAL: coverageNode,
                 HASH: T.stringLiteral(hash)
             });
+            cv._blockHoist = 3;
             path.node.body.unshift(cv);
             return {
                 fileCoverage: coverageData,


### PR DESCRIPTION
This sets `_blockHoist = 3` on the injected VariableDeclaration node, resulting in its being placed above any transpiled imports. Without this change, in the presence of circular dependencies, code from the instrumented file may be executed before the variable is initialized, crashing the instrumented program.

This is currently blocking the use of `babel-plugin-istanbul` on the Babel codebase itself.