### PR TITLE
fix: function declaration assignment retains function name

### DIFF
--- a/src/visitor.js
+++ b/src/visitor.js
@@ -189,6 +189,12 @@ class VisitState {
                 end: { line: n.loc.start.line, column: n.loc.start.column + 1 }
             };
         }
+        if (!n.id) {
+            const decl = path.find(node => node.isVariableDeclarator());
+            if (decl) {
+                n.id = decl.get('id').node;
+            }
+        }
         const name = path.node.id ? path.node.id.name : path.node.name;
         const index = this.cov.newFunction(name, dloc, path.node.body.loc);
         const increment = this.increase('f', index, null);

--- a/test/specs/functions.yaml
+++ b/test/specs/functions.yaml
@@ -95,3 +95,15 @@ tests:
     branches: {'0': [0, 1]}
     functions: {'0': 1, '1': 1}
     statements: {'0': 1, '1': 1, '2': 1 }
+
+---
+name: function declaration assignment name
+code: |
+  const foo = function() {}
+  output = foo.name;
+tests:
+  - name: properly sets function name
+    out: 'foo'
+    lines: {'1': 1, '2': 1}
+    functions: {'0': 0}
+    statements: {'0': 1, '1': 1}


### PR DESCRIPTION
This adds the fix to properly handle one of the failing tests described in this issue: https://github.com/istanbuljs/babel-plugin-istanbul/issues/63

The first commit specifically adds a failing test case. Once it fails on CI, I will push the fix that allows the test to pass.

@bcoe, please let me know if my test case is correct or needs to be modified. I went with what looked like was happening in the rest of the test suite, but I've never seen tests defined in YAML before. :)