### PR TITLE
Only set function name on top-level declarations

### DIFF
--- a/src/visitor.js
+++ b/src/visitor.js
@@ -191,7 +191,9 @@ class VisitState {
         }
         if (!n.id) {
             const decl = path.find(node => node.isVariableDeclarator());
-            if (decl) {
+            const functionParent = path.getFunctionParent();
+            // make sure we aren't messing with nested functions
+            if (decl && functionParent && functionParent.isProgram()) {
                 n.id = decl.get('id').node;
             }
         }

--- a/test/specs/functions.yaml
+++ b/test/specs/functions.yaml
@@ -107,3 +107,19 @@ tests:
     lines: {'1': 1, '2': 1}
     functions: {'0': 0}
     statements: {'0': 1, '1': 1}
+
+---
+name: ignore assigning nested function declaration names
+code: |
+  const foo = function() {
+    const bar = function() {}
+
+    output = [foo.name, bar.name];
+  }
+  foo();
+tests:
+  - name: ignores nested declaration
+    out: ['foo', '']
+    lines: {'1': 1, '2': 1, '4': 1, '6': 1}
+    functions: {'0': 1, '1': 0}
+    statements: {'0': 1, '1': 1, '2': 1, '3': 1}


### PR DESCRIPTION
This should solve #34.

It was difficult to come up with a test case that matches what was reported in https://github.com/babel/babel/issues/5048 because this library currently doesn't transform arrow functions.

Given this input: 

```js
const foo = arr => {
  // do stuff
  return arr.map(value => {
    if ( value === 1 ) {
      return foo([])
    }

    return [value]
  })
}
```

I setup a test repo and used the `istanbul-lib-instrument@1.3.1` which produced the following output:

```js
const foo = (++cov_i2ccljqdj.s[0], function foo(arr) {
  ++cov_i2ccljqdj.f[0];
  ++cov_i2ccljqdj.s[1];

  // do stuff
  return arr.map(function foo(value) {
    ++cov_i2ccljqdj.f[1];
    ++cov_i2ccljqdj.s[2];

    if (value === 1) {
      ++cov_i2ccljqdj.b[0][0];
      ++cov_i2ccljqdj.s[3];

      return foo([]);
    } else {
      ++cov_i2ccljqdj.b[0][1];
    }

    ++cov_i2ccljqdj.s[4];
    return [value];
  });
});
```

And when I `npm link istanbul-lib-instrument` with this branch I got the following result:

```js
const foo = (++cov_i2ccljqdj.s[0], function foo(arr) {
  ++cov_i2ccljqdj.f[0];
  ++cov_i2ccljqdj.s[1];

  // do stuff
  return arr.map(function (value) {
    ++cov_i2ccljqdj.f[1];
    ++cov_i2ccljqdj.s[2];

    if (value === 1) {
      ++cov_i2ccljqdj.b[0][0];
      ++cov_i2ccljqdj.s[3];

      return foo([]);
    } else {
      ++cov_i2ccljqdj.b[0][1];
    }

    ++cov_i2ccljqdj.s[4];
    return [value];
  });
});
```