### PR TITLE
Function declaration name should not be same name as a parameter

### DIFF
--- a/src/visitor.js
+++ b/src/visitor.js
@@ -192,7 +192,10 @@ class VisitState {
         if (!n.id) {
             const decl = path.find(node => node.isVariableDeclarator());
             if (decl) {
-                n.id = decl.get('id').node;
+                const fnName = decl.get('id.name').node;
+                const params = path.get('params').map(param => param.get('name').node);
+                const found = params.indexOf(fnName) > -1;
+                n.id = T.identifier(found ? `_${fnName}` : fnName);
             }
         }
         const name = path.node.id ? path.node.id.name : path.node.name;

--- a/test/specs/functions.yaml
+++ b/test/specs/functions.yaml
@@ -107,3 +107,15 @@ tests:
     lines: {'1': 1, '2': 1}
     functions: {'0': 0}
     statements: {'0': 1, '1': 1}
+
+---
+name: function declaration name should be different than parameter name
+code: |
+  const foo = function(a, foo) {}
+  output = foo.name;
+tests:
+  - name: should not be name of a parameter
+    out: _foo
+    lines: {'1': 1, '2': 1}
+    functions: {'0': 0}
+    statements: {'0': 1, '1': 1}


### PR DESCRIPTION
This should fix #35.

Should fix certain issues with browsers in strict mode.