### PR TITLE
Addd support for jsx and flow syntax, in addition to ES6

### DIFF
--- a/src/instrumenter.js
+++ b/src/instrumenter.js
@@ -61,7 +61,7 @@ class Instrumenter {
     }
     /**
      * instrument the supplied code and track coverage against the supplied
-     * filename. It throws if invalid code is passed to it. ES5 and ES6 syntax
+     * filename. It throws if invalid code is passed to it. ES5 and ES6 and JSX syntax
      * is supported. To instrument ES6 modules, make sure that you set the
      * `esModules` property to `true` when creating the instrumenter.
      *
@@ -80,7 +80,11 @@ class Instrumenter {
         const opts = this.opts;
         const ast = babylon.parse(code, {
             allowReturnOutsideFunction: opts.autoWrap,
-            sourceType: opts.esModules ? "module" : "script"
+            sourceType: opts.esModules ? "module" : "script",
+            plugins: [
+              'jsx',
+              'flow'
+            ]
         });
         const ee = programVisitor(t, filename, {
             coverageVariable: opts.coverageVariable,


### PR DESCRIPTION
We had issues using this to generate code coverage for ES6 with React and JSX Syntax. I am not sure wether you think it is a good idea to always activate these plugins, perhaps they should be opt-in but I could not see a reason as to why they shouldn't be there by default?

Anyway, this fixes a problem when using istanbul-instrumenter-loader together with ES6 + React (JSX). That project in turn uses istanbul-lib-instrument. 